### PR TITLE
feat: leverage abortable fetch to cancel requests on component unmount

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,13 +20,13 @@ export const App = (): JSX.Element => (
             </Link>
           </li>
           <li>
-            <Link to="/photos">
-              Photos
+            <Link to="/users">
+              Users
             </Link>
           </li>
           <li>
-            <Link to="/users">
-              Users
+            <Link to="/photos">
+              Photos
             </Link>
           </li>
         </ul>

--- a/src/scenes/photos/index.tsx
+++ b/src/scenes/photos/index.tsx
@@ -12,13 +12,16 @@ export interface Props {
   error: Error | null;
 
   // dispatch
+  cancelPhotos: () => void;
   loadPhotos: () => void;
 }
 
-const Photos = ({ photos, pending, error, loadPhotos }: Props): JSX.Element => {
-  useEffect((): void => {
+const Photos = ({ photos, pending, error, cancelPhotos, loadPhotos }: Props): JSX.Element => {
+  useEffect((): () => void => {
     loadPhotos();
-  }, [loadPhotos]);
+
+    return (): void => cancelPhotos();
+  }, [loadPhotos, cancelPhotos]);
 
   return (
     <>
@@ -44,6 +47,7 @@ const mapStateToProps = (state: CombinedAppState) => ({
 
 export const mapDispatchToProps = {
   loadPhotos: PhotosState.actions.loadPhotosRequest,
+  cancelPhotos: PhotosState.actions.loadPhotosCancel,
 };
 
 const ConnectedPhotos = connect(mapStateToProps, mapDispatchToProps)(Photos);

--- a/src/scenes/posts/index.tsx
+++ b/src/scenes/posts/index.tsx
@@ -12,13 +12,16 @@ export interface Props {
   error: Error | null;
 
   // dispatch
+  cancelPosts: () => void;
   loadPosts: () => void;
 }
 
-const Posts = ({ posts, pending, error, loadPosts }: Props): JSX.Element => {
-  useEffect((): void => {
+const Posts = ({ posts, pending, error, cancelPosts, loadPosts }: Props): JSX.Element => {
+  useEffect((): () => void => {
     loadPosts();
-  }, [loadPosts]);
+
+    return (): void => cancelPosts();
+  }, [loadPosts, cancelPosts]);
 
   return (
     <>
@@ -43,6 +46,7 @@ const mapStateToProps = (state: CombinedAppState) => ({
 });
 
 export const mapDispatchToProps = {
+  cancelPosts: PostsState.actions.loadPostsCancel,
   loadPosts: PostsState.actions.loadPostsRequest,
 };
 

--- a/src/scenes/users/index.tsx
+++ b/src/scenes/users/index.tsx
@@ -12,12 +12,15 @@ export interface Props {
   error: Error | null;
 
   // dispatch
+  cancelUsers: () => void;
   loadUsers: () => void;
 }
 
-const Users = ({ users, pending, error, loadUsers }: Props): JSX.Element => {
-  useEffect((): void => {
+const Users = ({ users, pending, error, cancelUsers, loadUsers }: Props): JSX.Element => {
+  useEffect((): () => void => {
     loadUsers();
+
+    return (): void => cancelUsers()
   }, [loadUsers]);
 
   return (
@@ -44,6 +47,7 @@ const mapStateToProps = (state: CombinedAppState) => ({
 
 export const mapDispatchToProps = {
   loadUsers: UsersState.actions.loadUsersRequest,
+  cancelUsers: UsersState.actions.loadUsersCancel,
 };
 
 const ConnectedUsers = connect(mapStateToProps, mapDispatchToProps)(Users);

--- a/src/services/state/network/api.ts
+++ b/src/services/state/network/api.ts
@@ -5,15 +5,19 @@ export enum Methods {
 export const get = async <T>({
   url,
   method = Methods.GET,
+  signal,
 }: {
   url: string;
   method?: Methods;
+  signal?: AbortSignal;
 }): Promise<T | null> => {
   try {
-    const response: Response = await fetch(url, {
-      method,
+    const request: Request = new Request(url, {
       headers: { "Content-Type": "application/json" },
+      method,
+      signal,
     });
+    const response = await fetch(request);
     const data: T = await response.json();
 
     return data;

--- a/src/services/state/photos/photos.saga.ts
+++ b/src/services/state/photos/photos.saga.ts
@@ -1,24 +1,33 @@
-import { all, call, put, takeLatest } from "redux-saga/effects";
+import { call, cancel, cancelled, fork, put, take } from "redux-saga/effects";
 
 import Endpoints from "../../../endpoints";
 import { get } from "../network/api";
 
 import PhotosState, { Photo } from "./photos.state";
 
-export function* handleLoadPhotos() {
+export function* handleLoadPhotos(): Generator {
+  const abortController: AbortController = new AbortController();
+
   try {
-    const photos: Photo[] = yield call(get, { url: Endpoints.photos });
+    const photos: Photo[] | any = yield call(get, { url: Endpoints.photos, signal: abortController.signal });
 
     yield put(PhotosState.actions.loadPhotosSuccess(photos));
   } catch (error) {
     yield put(PhotosState.actions.loadPhotosFailure(error as Error));
+  } finally {
+    if (yield cancelled()) {
+      abortController.abort();
+    }
   }
 }
 
-function* rootSaga() {
-  yield all([
-    takeLatest(PhotosState.types.FETCH_PHOTOS_REQUEST, handleLoadPhotos),
-  ]);
+function* rootSaga(): Generator {
+  while(yield take(PhotosState.types.FETCH_PHOTOS_REQUEST)) {
+    const fetchTask = yield fork(handleLoadPhotos);
+
+    yield take(PhotosState.types.FETCH_PHOTOS_CANCEL);
+    yield cancel(fetchTask as any);
+  }
 }
 
 export default rootSaga;

--- a/src/services/state/photos/photos.state.ts
+++ b/src/services/state/photos/photos.state.ts
@@ -30,12 +30,17 @@ export type PhotosState = {
 // constants
 const reducerName = "photos";
 const FETCH_PHOTOS_REQUEST = `${reducerName}/FETCH_PHOTOS_REQUEST`;
+const FETCH_PHOTOS_CANCEL = `${reducerName}/FETCH_PHOTOS_CANCEL`;
 const FETCH_PHOTOS_SUCCESS = `${reducerName}/FETCH_PHOTOS_SUCCESS`;
 const FETCH_PHOTOS_FAILURE = `${reducerName}/FETCH_PHOTOS_FAILURE`;
 
 // actions
 const loadPhotosRequest = (): PhotosAction => ({
   type: FETCH_PHOTOS_REQUEST,
+});
+
+const loadPhotosCancel = (): PhotosAction => ({
+  type: FETCH_PHOTOS_CANCEL,
 });
 
 const loadPhotosSuccess = (photos: Photo[]): PhotosAction => ({
@@ -94,11 +99,13 @@ const getError = createSelector(getPhotosState, ({ error }: PhotosState) => erro
 const photosState = {
   actions: {
     loadPhotosRequest,
+    loadPhotosCancel,
     loadPhotosSuccess,
     loadPhotosFailure,
   },
   types: {
     FETCH_PHOTOS_REQUEST,
+    FETCH_PHOTOS_CANCEL,
     FETCH_PHOTOS_SUCCESS,
     FETCH_PHOTOS_FAILURE,
   },

--- a/src/services/state/posts/posts.saga.ts
+++ b/src/services/state/posts/posts.saga.ts
@@ -1,24 +1,36 @@
-import { all, call, put, takeLatest } from 'redux-saga/effects';
+import { call, cancel, cancelled, fork, put, take } from "redux-saga/effects";
 
-import Endpoints from '../../../endpoints';
-import { get } from '../network/api'
+import Endpoints from "../../../endpoints";
+import { get } from "../network/api";
 
-import PostsState, { Post } from './posts.state'
+import PostsState, { Post } from "./posts.state";
 
-export function* handleLoadPosts() {
+export function* handleLoadPosts(): Generator {
+  const abortController: AbortController = new AbortController();
+
   try {
-    const posts: Post[] = yield call(get, { url: Endpoints.posts })
+    const posts: Post[] | any = yield call(get, {
+      url: Endpoints.posts,
+      signal: abortController.signal,
+    });
 
     yield put(PostsState.actions.loadPostsSuccess(posts));
-  } catch(error) {
+  } catch (error) {
     yield put(PostsState.actions.loadPostsFailure(error as Error));
-  } 
+  } finally {
+    if (yield cancelled()) {
+      abortController.abort();
+    }
+  }
 }
 
-function* rootSaga() {
-  yield all([
-    takeLatest(PostsState.types.FETCH_POSTS_REQUEST, handleLoadPosts)
-  ])
+function* rootSaga (): Generator {
+  while(yield take(PostsState.types.FETCH_POSTS_REQUEST)) {
+    const fetchTask = yield fork(handleLoadPosts);
+
+    yield take(PostsState.types.FETCH_POSTS_CANCEL);
+    yield cancel(fetchTask as any);
+  }
 }
 
 export default rootSaga;

--- a/src/services/state/posts/posts.state.ts
+++ b/src/services/state/posts/posts.state.ts
@@ -29,12 +29,17 @@ export type PostsState = {
 // constants
 const reducerName = "posts";
 const FETCH_POSTS_REQUEST = `${reducerName}/FETCH_POSTS_REQUEST`;
+const FETCH_POSTS_CANCEL = `${reducerName}/FETCH_POSTS_CANCEL`;
 const FETCH_POSTS_SUCCESS = `${reducerName}/FETCH_POSTS_SUCCESS`;
 const FETCH_POSTS_FAILURE = `${reducerName}/FETCH_POSTS_FAILURE`;
 
 // actions
 const loadPostsRequest = (): PostsAction => ({
   type: FETCH_POSTS_REQUEST,
+});
+
+const loadPostsCancel = (): PostsAction => ({
+  type: FETCH_POSTS_CANCEL,
 });
 
 const loadPostsSuccess = (posts: Post[]): PostsAction => ({
@@ -93,11 +98,13 @@ const getError = createSelector(getPostsState, ({ error }: PostsState) => error)
 const postsState = {
   actions: {
     loadPostsRequest,
+    loadPostsCancel,
     loadPostsSuccess,
     loadPostsFailure,
   },
   types: {
     FETCH_POSTS_REQUEST,
+    FETCH_POSTS_CANCEL,
     FETCH_POSTS_SUCCESS,
     FETCH_POSTS_FAILURE,
   },

--- a/src/services/state/users/users.saga.ts
+++ b/src/services/state/users/users.saga.ts
@@ -1,24 +1,33 @@
-import { all, call, put, takeLatest } from "redux-saga/effects";
+import { call, cancel, cancelled, fork, put, take } from "redux-saga/effects";
 
 import Endpoints from "../../../endpoints";
 import { get } from "../network/api";
 
 import UsersState, { User } from "./users.state";
 
-export function* handleLoadUsers() {
+export function* handleLoadUsers(): Generator {
+  const abortController: AbortController = new AbortController();
+
   try {
-    const photos: User[] = yield call(get, { url: Endpoints.users });
+    const photos: User[] | any = yield call(get, { url: Endpoints.users, signal: abortController.signal });
 
     yield put(UsersState.actions.loadUsersSuccess(photos));
   } catch (error) {
     yield put(UsersState.actions.loadUsersFailure(error as Error));
+  } finally {
+    if (yield cancelled()) {
+      abortController.abort();
+    }
   }
 }
 
-function* rootSaga() {
-  yield all([
-    takeLatest(UsersState.types.FETCH_USERS_REQUEST, handleLoadUsers),
-  ]);
+function* rootSaga(): Generator {
+  while(yield take(UsersState.types.FETCH_USERS_REQUEST)) {
+    const fetchTask = yield fork(handleLoadUsers);
+
+    yield take(UsersState.types.FETCH_USERS_CANCEL);
+    yield cancel(fetchTask as any);
+  }
 }
 
 export default rootSaga;

--- a/src/services/state/users/users.state.ts
+++ b/src/services/state/users/users.state.ts
@@ -46,12 +46,17 @@ export type UsersState = {
 // constants
 const reducerName = "users";
 const FETCH_USERS_REQUEST = `${reducerName}/FETCH_USERS_REQUEST`;
+const FETCH_USERS_CANCEL = `${reducerName}/FETCH_USERS_CANCEL`;
 const FETCH_USERS_SUCCESS = `${reducerName}/FETCH_USERS_SUCCESS`;
 const FETCH_USERS_FAILURE = `${reducerName}/FETCH_USERS_FAILURE`;
 
 // actions
 const loadUsersRequest = (): UsersAction => ({
   type: FETCH_USERS_REQUEST,
+});
+
+const loadUsersCancel = (): UsersAction => ({
+  type: FETCH_USERS_CANCEL,
 });
 
 const loadUsersSuccess = (users: User[]): UsersAction => ({
@@ -119,11 +124,13 @@ const getError = createSelector(
 const usersState = {
   actions: {
     loadUsersRequest,
+    loadUsersCancel,
     loadUsersSuccess,
     loadUsersFailure,
   },
   types: {
     FETCH_USERS_REQUEST,
+    FETCH_USERS_CANCEL,
     FETCH_USERS_SUCCESS,
     FETCH_USERS_FAILURE,
   },


### PR DESCRIPTION
**What is this?**

This PR updates the redux saga flow to incorporate an abort signal into api fetch calls.

When the user navigates to a view and a call is made to load some data, the call will be cancelled when the user navigates away before the call has finished.